### PR TITLE
Changed emoji code operators -> verbatim statements

### DIFF
--- a/app/evaluator/Evaluator.hs
+++ b/app/evaluator/Evaluator.hs
@@ -21,7 +21,7 @@ ioPrimitives = [("apply", applyProc),
 
 makePort :: IOMode -> [Values] -> IOThrowsError Values
 makePort mode [String filename] = fmap Port $ liftIO $ openFile filename mode
-makePort _ _ = throwError $ Default "Whoops 🤭! There is an unknown error!"
+makePort _ _ = throwError $ Default "Whoops! There is an unknown error!"
 
 closePort :: [Values] -> IOThrowsError Values
 closePort [Port port] = liftIO $ hClose port >> return (Bool True)
@@ -30,28 +30,28 @@ closePort _           = return $ Bool False
 readProc :: [Values] -> IOThrowsError Values
 readProc []          = readProc [Port stdin]
 readProc [Port port] = liftIO (hGetLine port) >>= liftThrows . readExpr
-readProc _           = throwError $ Default "Whoops 🤭! There is an unknown error!"
+readProc _           = throwError $ Default "Whoops! There is an unknown error!"
 
 writeProc :: [Values] -> IOThrowsError Values
 writeProc [obj]            = writeProc [obj, Port System.IO.stdout]
 writeProc [obj, Port port] = liftIO $ hPrint port obj >> return (Bool True)
-writeProc _                = throwError $ Default "Whoops 🤭! There is an unknown error!"
+writeProc _                = throwError $ Default "Whoops! There is an unknown error!"
 
 applyProc :: [Values] -> IOThrowsError Values
 applyProc [func, List args] = apply func args
 applyProc (func : args)     = apply func args
-applyProc _                 = throwError $ Default "Whoops 🤭! There is an unknown error!"
+applyProc _                 = throwError $ Default "Whoops! There is an unknown error!"
 
 readContents :: [Values] -> IOThrowsError Values
 readContents [String filename] = fmap String $ liftIO $ readFile filename
-readContents _ = throwError $ Default "Whoops 🤭! There is an unknown error!"
+readContents _ = throwError $ Default "Whoops! There is an unknown error!"
 
 load :: String -> IOThrowsError [Values]
 load filename = liftIO (readFile filename) >>= liftThrows . readExprList
 
 readAll :: [Values] -> IOThrowsError Values
 readAll [String filename] = List <$> load filename
-readAll _ = throwError $ Default "Whoops 🤭! There is an unknown error!"
+readAll _ = throwError $ Default "Whoops! There is an unknown error!"
 
 apply :: Values -> [Values] -> ExceptT Errors IO Values
 apply (PrimitiveFunc func) args = liftThrows $ func args
@@ -66,7 +66,7 @@ apply (Func fparams varargs fbody fclosure) args =
                 Just argName -> liftIO $ bindVars env [(argName, List remainingArgs)]
                 Nothing -> return env
 apply (IOFunc func) args = func args
-apply _ _ = throwError $ Default "Whoops 🤭! There is an unknown error!"
+apply _ _ = throwError $ Default "Whoops! There is an unknown error!"
 
 makeFunc :: Monad m => Maybe String -> IOEnvironment -> [Values] -> [Values] -> m Values
 makeFunc varargs env fparams fbody = return $ Func (map showValue fparams) varargs fbody env

--- a/app/evaluator/Variables.hs
+++ b/app/evaluator/Variables.hs
@@ -5,13 +5,13 @@ import Data.IORef
 
 getVar :: IOEnvironment -> String -> IOThrowsError Values
 getVar envRef var  =  do env <- liftIO $ readIORef envRef
-                         maybe (throwError $ UnboundVar "Whoops 🤣! Getting unbound variable" var)
+                         maybe (throwError $ UnboundVar "Whoops! Getting unbound variable" var)
                                (liftIO . readIORef)
                                (lookup var env)
 
 setVar :: IOEnvironment -> String -> Values -> IOThrowsError Values
 setVar envRef var value = do env <- liftIO $ readIORef envRef
-                             maybe (throwError $ UnboundVar "LOL 😂!Setting an unbound variable" var)
+                             maybe (throwError $ UnboundVar "LOL! Setting an unbound variable" var)
                                    (liftIO . (`writeIORef` value))
                                    (lookup var env)
                              return value

--- a/app/types/Symbols.hs
+++ b/app/types/Symbols.hs
@@ -4,36 +4,36 @@ import Data.Maybe (fromMaybe)
 
 operatorSymbols :: [(String, String)]
 operatorSymbols = [
-  ("true", "👍"),
-  ("false", "👎"),
-  ("add", "➕"),
-  ("subtract", "➖"),
-  ("multiply", "✖️"),
-  ("divide", "➗"),
-  ("modulo", "🕒"),
-  ("remainder", "🍕"),
-  ("strong_equal", "🟰💪"),
-  ("weak_equal", "🟰😩"),
-  ("not_equal", "🚫"),
-  ("less_than_eq", "🟰️⬇️"),
-  ("greater_than_eq", "🟰️⬆️"),
-  ("less_than", "⬇️"),
-  ("greater_than", "⬆️"),
-  ("and", "🌑" ),
-  ("or", "🌕"),
-  ("strong_equal_str", "🧵[🟰💪]"),
-  ("not_equal_str", "🧵[🚫]"),
-  ("less_than_eq_str", "🧵[🟰️⬇️]"),
-  ("greater_than_eq_str", "🧵[🟰⬆️]"),
-  ("less_than_str", "🧵[⬇️]"),
-  ("greater_than_str", "🧵[⬆️]"),
-  ("head", "🧠"),
-  ("tail", "🍤"),
-  ("cons", "🛠️")
+  ("true", "truthful"),
+  ("false", "falseful"),
+  ("add", "add_numbers"),
+  ("subtract", "subtract_numbers"),
+  ("multiply", "multiply_numbers"),
+  ("divide", "divide_numbers"),
+  ("modulo", "obtain_modulu"),
+  ("remainder", "obtain_remainder"),
+  ("strong_equal", "is_equal_with_strength"),
+  ("weak_equal", "is_equal_with_weakness"),
+  ("not_equal", "is_not_equal"),
+  ("less_than_eq", "is_less_than_or_equal_to"),
+  ("greater_than_eq", "is_greater_than_or_equal_to"),
+  ("less_than", "is_less_than"),
+  ("greater_than", "is_greater_than"),
+  ("and", "and" ),
+  ("or", "or"),
+  ("strong_equal_str", "strings_is_equal_with_strength"),
+  ("not_equal_str", "strings_is_not_equal_to"),
+  ("less_than_eq_str", "strings_is_less_than_or_equal_to"),
+  ("greater_than_eq_str", "strings_is_less_than_or_equal_to"),
+  ("less_than_str", "strings_is_less_than"),
+  ("greater_than_str", "strings_is_greater_than"),
+  ("head", "obtain_head_of_list"),
+  ("tail", "obtain_tail_of_list"),
+  ("cons", "build_list_with")
   ]
 
 symbol :: Parser Char
-symbol = oneOf "[]!#$%&|*+-/:<=>?@^_~a🛠️🍤🧠👍👎➕➖✖️➗🕒🍕💪😩🚫⬇️⬆️🧵"
+symbol = oneOf "[]!#$%&|*+-/:<=>?@^_~a"
 
 lookupSymbol :: String -> String
 lookupSymbol key = fromMaybe "" (lookup key operatorSymbols)

--- a/app/types/Values.hs
+++ b/app/types/Values.hs
@@ -52,10 +52,10 @@ showError :: Errors -> String
 showError (UnboundVar msg var) = msg ++ ": " ++ var
 showError (BadSpecialForm msg form) = msg ++ ": " ++ show form
 showError (NotFunction msg f) = msg ++ ": " ++ show f
-showError (ArgumentNumber expect found) = "Oh no, we want " ++ show expect ++ " args 🤭; found values " ++ unwordsList found
-showError (TypeMismatch expect found) = "Oops! Wrong type 🤭: expected " ++ expect ++ ", found " ++ show found
-showError (Parser parseErr) = "Sorry! Cannot parse 🤭" ++ show parseErr
-showError (Default err) = "There is an error 🤭: " ++ err
+showError (ArgumentNumber expect found) = "Oh no, we want " ++ show expect ++ " args; found values " ++ unwordsList found
+showError (TypeMismatch expect found) = "Oops! Wrong type: expected " ++ expect ++ ", found " ++ show found
+showError (Parser parseErr) = "Sorry! Cannot parse" ++ show parseErr
+showError (Default err) = "There is an error: " ++ err
 
 instance Show Values where show = showValue
 instance Show Errors where show = showError


### PR DESCRIPTION
Fixes #15 

Operators manifests as a statement (ex. `+` -> `add_numbers`). 

Expressions in this language are structured in Polish notation, so I decided to display operators as functions. Operators will no longer exist in this language.